### PR TITLE
Add skeleton routes

### DIFF
--- a/apps/client/src/components/Page.tsx
+++ b/apps/client/src/components/Page.tsx
@@ -1,0 +1,6 @@
+import styled from 'styled-components';
+
+export const Page = styled.div`
+  padding: 2rem;
+`;
+

--- a/apps/client/src/components/ProtectedRoute.tsx
+++ b/apps/client/src/components/ProtectedRoute.tsx
@@ -1,0 +1,10 @@
+import { Navigate } from 'react-router-dom';
+import type { ReactNode } from 'react';
+
+export const ProtectedRoute = ({ children }: { children: ReactNode }) => {
+  const token = localStorage.getItem('token');
+  if (!token) {
+    return <Navigate to="/login" replace />;
+  }
+  return <>{children}</>;
+};

--- a/apps/client/src/pages/CaseAnalyze.tsx
+++ b/apps/client/src/pages/CaseAnalyze.tsx
@@ -1,0 +1,12 @@
+import { Page } from '../components/Page';
+import { useParams } from 'react-router-dom';
+
+export const CaseAnalyze = () => {
+  const { id } = useParams();
+  return (
+    <Page>
+      <h2>Analyze Case {id}</h2>
+      <p>AI analysis results will appear here.</p>
+    </Page>
+  );
+};

--- a/apps/client/src/pages/CaseDetails.tsx
+++ b/apps/client/src/pages/CaseDetails.tsx
@@ -1,0 +1,12 @@
+import { Page } from '../components/Page';
+import { useParams } from 'react-router-dom';
+
+export const CaseDetails = () => {
+  const { id } = useParams();
+  return (
+    <Page>
+      <h2>Case {id}</h2>
+      <p>Details for case {id} will appear here.</p>
+    </Page>
+  );
+};

--- a/apps/client/src/pages/CaseDocuments.tsx
+++ b/apps/client/src/pages/CaseDocuments.tsx
@@ -1,0 +1,12 @@
+import { Page } from '../components/Page';
+import { useParams } from 'react-router-dom';
+
+export const CaseDocuments = () => {
+  const { id } = useParams();
+  return (
+    <Page>
+      <h2>Case {id} Documents</h2>
+      <p>Documents list will appear here.</p>
+    </Page>
+  );
+};

--- a/apps/client/src/pages/CaseEdit.tsx
+++ b/apps/client/src/pages/CaseEdit.tsx
@@ -1,0 +1,12 @@
+import { Page } from '../components/Page';
+import { useParams } from 'react-router-dom';
+
+export const CaseEdit = () => {
+  const { id } = useParams();
+  return (
+    <Page>
+      <h2>Edit Case {id}</h2>
+      <p>Case editing form will appear here.</p>
+    </Page>
+  );
+};

--- a/apps/client/src/pages/CasesList.tsx
+++ b/apps/client/src/pages/CasesList.tsx
@@ -1,0 +1,8 @@
+import { Page } from '../components/Page';
+
+export const CasesList = () => (
+  <Page>
+    <h2>Cases</h2>
+    <p>List of cases will appear here.</p>
+  </Page>
+);

--- a/apps/client/src/pages/DocumentUpload.tsx
+++ b/apps/client/src/pages/DocumentUpload.tsx
@@ -1,0 +1,12 @@
+import { Page } from '../components/Page';
+import { useParams } from 'react-router-dom';
+
+export const DocumentUpload = () => {
+  const { id } = useParams();
+  return (
+    <Page>
+      <h2>Upload Document for Case {id}</h2>
+      <p>Document upload form will appear here.</p>
+    </Page>
+  );
+};

--- a/apps/client/src/pages/Draft.tsx
+++ b/apps/client/src/pages/Draft.tsx
@@ -1,0 +1,12 @@
+import { Page } from '../components/Page';
+import { useParams } from 'react-router-dom';
+
+export const Draft = () => {
+  const { type } = useParams();
+  return (
+    <Page>
+      <h2>Create Draft: {type}</h2>
+      <p>Draft editor for {type} will appear here.</p>
+    </Page>
+  );
+};

--- a/apps/client/src/pages/Login.tsx
+++ b/apps/client/src/pages/Login.tsx
@@ -1,8 +1,8 @@
-export const Login = () => {
-  return (
-    <div style={{ padding: '2rem' }}>
-      <h2>Login</h2>
-      <p>Here we will build the login form...</p>
-    </div>
-  );
-};
+import { Page } from '../components/Page';
+
+export const Login = () => (
+  <Page>
+    <h2>Login</h2>
+    <p>Here we will build the login form...</p>
+  </Page>
+);

--- a/apps/client/src/pages/Profile.tsx
+++ b/apps/client/src/pages/Profile.tsx
@@ -1,0 +1,8 @@
+import { Page } from '../components/Page';
+
+export const Profile = () => (
+  <Page>
+    <h2>User Profile</h2>
+    <p>Profile information will appear here.</p>
+  </Page>
+);

--- a/apps/client/src/routes/AppRoutes.tsx
+++ b/apps/client/src/routes/AppRoutes.tsx
@@ -1,21 +1,94 @@
 import { Routes, Route } from 'react-router-dom';
 import { Login } from '../pages/Login';
+import { CasesList } from '../pages/CasesList';
+import { CaseDetails } from '../pages/CaseDetails';
+import { CaseEdit } from '../pages/CaseEdit';
+import { CaseDocuments } from '../pages/CaseDocuments';
+import { DocumentUpload } from '../pages/DocumentUpload';
+import { CaseAnalyze } from '../pages/CaseAnalyze';
+import { Draft } from '../pages/Draft';
+import { Profile } from '../pages/Profile';
+import { ProtectedRoute } from '../components/ProtectedRoute';
 import { Button } from '../components/Button';
 import { MainLayout } from './MainLayout';
 
 export const AppRoutes = () => (
-    <Routes>
-        <Route element={<MainLayout />}>
-            <Route
-                path="/"
-                element={
-                    <main style={{ padding: '2rem' }}>
-                        <h1>Legal Platform – Client</h1>
-                        <Button>התחל</Button>
-                    </main>
-                }
-            />
-            <Route path="/login" element={<Login />} />
-        </Route>
-    </Routes>
+  <Routes>
+    <Route element={<MainLayout />}>
+      <Route
+        path="/"
+        element={
+          <main style={{ padding: '2rem' }}>
+            <h1>Legal Platform – Client</h1>
+            <Button>התחל</Button>
+          </main>
+        }
+      />
+      <Route path="/login" element={<Login />} />
+      <Route
+        path="/cases"
+        element={
+          <ProtectedRoute>
+            <CasesList />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/cases/:id"
+        element={
+          <ProtectedRoute>
+            <CaseDetails />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/cases/:id/edit"
+        element={
+          <ProtectedRoute>
+            <CaseEdit />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/cases/:id/documents"
+        element={
+          <ProtectedRoute>
+            <CaseDocuments />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/cases/:id/documents/upload"
+        element={
+          <ProtectedRoute>
+            <DocumentUpload />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/cases/:id/analyze"
+        element={
+          <ProtectedRoute>
+            <CaseAnalyze />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/drafts/:type"
+        element={
+          <ProtectedRoute>
+            <Draft />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/me"
+        element={
+          <ProtectedRoute>
+            <Profile />
+          </ProtectedRoute>
+        }
+      />
+    </Route>
+  </Routes>
 );

--- a/apps/client/src/routes/MainLayout.tsx
+++ b/apps/client/src/routes/MainLayout.tsx
@@ -16,11 +16,13 @@ const Nav = styled.nav`
 `;
 
 export const MainLayout = ({ children }: { children?: ReactNode }) => (
-    <Wrapper>
-        <Nav>
-            <Link to="/">בית</Link>
-            <Link to="/login">התחברות</Link>
-        </Nav>
-        {children ?? <Outlet />}
-    </Wrapper>
+  <Wrapper>
+    <Nav>
+      <Link to="/">בית</Link>
+      <Link to="/cases">תיקים</Link>
+      <Link to="/me">פרופיל</Link>
+      <Link to="/login">התחברות</Link>
+    </Nav>
+    {children ?? <Outlet />}
+  </Wrapper>
 );


### PR DESCRIPTION
## Summary
- add skeleton pages for cases, drafts, profile, and more
- add a protected route component
- build out main navigation and route mapping

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885094283f48321b38fc027254bc644